### PR TITLE
feat: add dark mode toggle with persistent theme preference

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ xattr -c /Applications/Groq\ Desktop.app
 
 - Chat interface with image support
 - Local MCP servers
+- Dark mode toggle with persistent theme preference
 
 ## Prerequisites
 
@@ -148,6 +149,10 @@ In the settings page, add your Groq API key:
 ```
 
 You can obtain a Groq API key by signing up at [https://console.groq.com](https://console.groq.com).
+
+### Dark Mode
+
+The app now includes a dark mode toggle in the Settings page. Toggle between light and dark themes, and your preference will persist across app restarts. The theme is applied immediately when changed and stored in your user settings.
 
 ## Contributing
 

--- a/electron/settingsManager.js
+++ b/electron/settingsManager.js
@@ -23,7 +23,8 @@ function loadSettings() {
             customCompletionUrl: '',
             toolOutputLimit: 8000,
             customApiBaseUrl: '',
-            customModels: {}
+            customModels: {},
+            theme: 'light'
         };
     }
     const userDataPath = appInstance.getPath('userData');
@@ -40,7 +41,8 @@ function loadSettings() {
         customCompletionUrl: '',
         toolOutputLimit: 8000,
         customApiBaseUrl: '',
-        customModels: {}
+        customModels: {},
+        theme: 'light'
     };
 
     try {
@@ -79,6 +81,7 @@ function loadSettings() {
             settings.toolOutputLimit = settings.toolOutputLimit ?? defaultSettings.toolOutputLimit;
             settings.customApiBaseUrl = settings.customApiBaseUrl || defaultSettings.customApiBaseUrl;
             settings.customModels = settings.customModels || defaultSettings.customModels;
+            settings.theme = settings.theme || defaultSettings.theme;
 
             // Optional: Persist the potentially updated settings back to file if defaults were applied
             // fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2));

--- a/src/renderer/App.jsx
+++ b/src/renderer/App.jsx
@@ -153,6 +153,40 @@ function App() {
     }
   };
 
+  // Function to apply theme
+  const applyTheme = (theme) => {
+    if (theme === 'dark') {
+      document.documentElement.classList.add('dark');
+    } else {
+      document.documentElement.classList.remove('dark');
+    }
+  };
+
+  // Apply theme to document root on mount
+  useEffect(() => {
+    const loadAndApplyTheme = async () => {
+      try {
+        const settings = await window.electron.getSettings();
+        const theme = settings?.theme || 'light';
+        applyTheme(theme);
+      } catch (error) {
+        console.error('Error applying theme:', error);
+        // Default to light mode on error
+        applyTheme('light');
+      }
+    };
+
+    loadAndApplyTheme();
+    
+    // Make theme function available globally for settings page
+    window.updateTheme = applyTheme;
+    
+    // Cleanup
+    return () => {
+      delete window.updateTheme;
+    };
+  }, []);
+
   // Load settings, MCP tools, and model configs when component mounts
   useEffect(() => {
     const loadInitialData = async () => {

--- a/src/renderer/pages/Settings.jsx
+++ b/src/renderer/pages/Settings.jsx
@@ -23,6 +23,7 @@ function Settings() {
     toolOutputLimit: 8000,
     customApiBaseUrl: '',
     customModels: {},
+    theme: 'light',
     builtInTools: {
       codeInterpreter: false,
       browserSearch: false
@@ -70,6 +71,9 @@ function Settings() {
                 browserSearch: false
             };
         }
+        if (!settingsData.theme) {
+            settingsData.theme = 'light';
+        }
         setSettings(settingsData);
       } catch (error) {
         console.error('Error loading settings:', error);
@@ -86,6 +90,7 @@ function Settings() {
             toolOutputLimit: 8000,
             customApiBaseUrl: '',
             customModels: {},
+            theme: 'light',
             builtInTools: {
                 codeInterpreter: false,
                 browserSearch: false
@@ -155,10 +160,15 @@ function Settings() {
     saveSettings(updatedSettings);
   };
 
-  const handleToggleChange = (name, checked) => {
-    const updatedSettings = { ...settings, [name]: checked };
+  const handleToggleChange = (name, value) => {
+    const updatedSettings = { ...settings, [name]: value };
     setSettings(updatedSettings);
     saveSettings(updatedSettings);
+    
+    // Immediately apply theme change if it's a theme toggle
+    if (name === 'theme' && window.updateTheme) {
+      window.updateTheme(value);
+    }
   };
 
   const handleBuiltInToolToggle = (toolName, checked) => {
@@ -922,6 +932,28 @@ function Settings() {
                     id="popup-enabled"
                     checked={settings.popupEnabled}
                     onChange={(e) => handleToggleChange('popupEnabled', e.target.checked)}
+                  />
+                </div>
+              </CardContent>
+            </Card>
+
+            {/* Dark Mode Settings */}
+            <Card>
+              <CardHeader>
+                <CardTitle>Dark Mode</CardTitle>
+                <CardDescription>
+                  Switch between light and dark themes. Your preference will persist across restarts.
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <div className="flex items-center justify-between">
+                  <Label htmlFor="dark-mode" className="font-medium">
+                    Enable Dark Mode
+                  </Label>
+                  <Switch
+                    id="dark-mode"
+                    checked={settings.theme === 'dark'}
+                    onChange={(e) => handleToggleChange('theme', e.target.checked ? 'dark' : 'light')}
                   />
                 </div>
               </CardContent>


### PR DESCRIPTION
Resolves #4

Implemented dark mode toggle functionality:

- Add theme setting to settingsManager.js with default 'light' value
- Add Dark Mode toggle card in Settings.jsx with immediate theme application
- Implement theme persistence using existing settings system (get/set)
- Apply Tailwind 'dark' class to <html> element in App.jsx based on stored setting
- Theme changes apply immediately when toggled and persist across app restarts
- Update README.md with dark mode feature documentation

🤖 Generated with [Claude Code](https://claude.ai/code)