### PR TITLE
fix: Dark mode toggle now properly enables and disables

### DIFF
--- a/src/renderer/components/ui/Switch.jsx
+++ b/src/renderer/components/ui/Switch.jsx
@@ -9,12 +9,8 @@ const Switch = ({ checked, onChange, id }) => {
         className="sr-only peer"
         checked={checked}
         onChange={onChange}
-        readOnly
       />
-      <div
-        onClick={onChange}
-        className="w-11 h-6 bg-gray-200 rounded-full peer peer-focus:ring-2 peer-focus:ring-blue-500 dark:peer-focus:ring-blue-600 dark:bg-gray-700 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-0.5 after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all dark:border-gray-600 peer-checked:bg-blue-600"
-      ></div>
+      <div className="w-11 h-6 bg-gray-200 rounded-full peer peer-focus:ring-2 peer-focus:ring-blue-500 dark:peer-focus:ring-blue-600 dark:bg-gray-700 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-0.5 after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all dark:border-gray-600 peer-checked:bg-blue-600"></div>
     </label>
   );
 };


### PR DESCRIPTION
Fixes #6

The dark mode toggle was getting stuck in ON position because:
1. The input element had readOnly attribute preventing state changes
2. Duplicate onClick handler on div conflicted with input onChange

This fix removes both issues, allowing proper toggle functionality for all Switch components.

Generated with [Claude Code](https://claude.ai/code)