### PR TITLE
feat(chat): add native spell-check support with toggle in settings

### DIFF
--- a/electron/settingsManager.js
+++ b/electron/settingsManager.js
@@ -24,7 +24,8 @@ function loadSettings() {
             toolOutputLimit: 8000,
             customApiBaseUrl: '',
             customModels: {},
-            theme: 'light'
+            theme: 'light',
+            enableSpellCheck: true
         };
     }
     const userDataPath = appInstance.getPath('userData');
@@ -42,7 +43,8 @@ function loadSettings() {
         toolOutputLimit: 8000,
         customApiBaseUrl: '',
         customModels: {},
-        theme: 'light'
+        theme: 'light',
+        enableSpellCheck: true
     };
 
     try {
@@ -82,6 +84,7 @@ function loadSettings() {
             settings.customApiBaseUrl = settings.customApiBaseUrl || defaultSettings.customApiBaseUrl;
             settings.customModels = settings.customModels || defaultSettings.customModels;
             settings.theme = settings.theme || defaultSettings.theme;
+            settings.enableSpellCheck = settings.enableSpellCheck ?? defaultSettings.enableSpellCheck;
 
             // Optional: Persist the potentially updated settings back to file if defaults were applied
             // fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2));

--- a/src/renderer/App.jsx
+++ b/src/renderer/App.jsx
@@ -83,6 +83,8 @@ function App() {
   const [visionSupported, setVisionSupported] = useState(false);
   // Add state to track if initial model/settings load is complete
   const [initialLoadComplete, setInitialLoadComplete] = useState(false);
+  // State for spell check setting
+  const [enableSpellCheck, setEnableSpellCheck] = useState(true);
 
   // --- State for Tool Approval Flow ---
   const [pendingApprovalCall, setPendingApprovalCall] = useState(null); // Holds the tool call object needing approval
@@ -220,6 +222,8 @@ function App() {
 
         setSelectedModel(effectiveModel); // Set the final selected model state
 
+        // Load spell check setting
+        setEnableSpellCheck(settings?.enableSpellCheck ?? true);
 
         // Initial load of MCP tools (can happen after model/settings)
         const mcpToolsResult = await window.electron.getMcpTools();
@@ -990,6 +994,7 @@ function App() {
                     onModelChange={setSelectedModel}
                     onOpenMcpTools={() => setIsToolsPanelOpen(true)}
                     modelConfigs={modelConfigs}
+                    enableSpellCheck={enableSpellCheck}
                   />
                 </div>
               </div>
@@ -1015,6 +1020,7 @@ function App() {
                     onModelChange={setSelectedModel}
                     onOpenMcpTools={() => setIsToolsPanelOpen(true)}
                     modelConfigs={modelConfigs}
+                    enableSpellCheck={enableSpellCheck}
                   />
                 </div>
               </div>

--- a/src/renderer/components/ChatInput.jsx
+++ b/src/renderer/components/ChatInput.jsx
@@ -21,6 +21,7 @@ function ChatInput({
 	onModelChange,
 	onOpenMcpTools,
 	modelConfigs = {},
+	enableSpellCheck = true,
 }) {
 	const [message, setMessage] = useState("");
 	const [suggestion, setSuggestion] = useState("");
@@ -370,6 +371,9 @@ function ChatInput({
 							onPaste={handlePaste}
 							onHeightChange={handleHeightChange}
 							placeholder={isDragOver ? "Drop files here..." : "Ask Groq anything..."}
+							spellCheck={enableSpellCheck}
+							autoCorrect={enableSpellCheck ? "on" : "off"}
+							autoCapitalize={enableSpellCheck ? "sentences" : "off"}
 							className={cn(
 								"w-full px-4 py-3 bg-background/80 backdrop-blur-sm resize-none border rounded-2xl text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring/50 focus:border-ring/50 transition-all duration-200",
 								isDragOver 

--- a/src/renderer/pages/Settings.jsx
+++ b/src/renderer/pages/Settings.jsx
@@ -24,6 +24,7 @@ function Settings() {
     customApiBaseUrl: '',
     customModels: {},
     theme: 'light',
+    enableSpellCheck: true,
     builtInTools: {
       codeInterpreter: false,
       browserSearch: false
@@ -74,6 +75,9 @@ function Settings() {
         if (!settingsData.theme) {
             settingsData.theme = 'light';
         }
+        if (settingsData.enableSpellCheck === undefined) {
+            settingsData.enableSpellCheck = true;
+        }
         setSettings(settingsData);
       } catch (error) {
         console.error('Error loading settings:', error);
@@ -91,6 +95,7 @@ function Settings() {
             customApiBaseUrl: '',
             customModels: {},
             theme: 'light',
+            enableSpellCheck: true,
             builtInTools: {
                 codeInterpreter: false,
                 browserSearch: false
@@ -954,6 +959,28 @@ function Settings() {
                     id="dark-mode"
                     checked={settings.theme === 'dark'}
                     onChange={(e) => handleToggleChange('theme', e.target.checked ? 'dark' : 'light')}
+                  />
+                </div>
+              </CardContent>
+            </Card>
+
+            {/* Spell Check Settings */}
+            <Card>
+              <CardHeader>
+                <CardTitle>Spell Check</CardTitle>
+                <CardDescription>
+                  Enable native spell-checking with red underlines for typos in the chat input. Uses your browser's built-in spell checker.
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <div className="flex items-center justify-between">
+                  <Label htmlFor="spell-check" className="font-medium">
+                    Enable Spell Check
+                  </Label>
+                  <Switch
+                    id="spell-check"
+                    checked={settings.enableSpellCheck}
+                    onChange={(e) => handleToggleChange('enableSpellCheck', e.target.checked)}
                   />
                 </div>
               </CardContent>


### PR DESCRIPTION
Implements native spell-check functionality for ChatInput component as requested in issue #8.

## Changes
- Add enableSpellCheck setting to settingsManager with default true
- Create spell-check toggle UI in Settings page with description
- Pass spell-check setting from App to ChatInput components
- Apply native HTML attributes to TextAreaAutosize: spellCheck, autoCorrect, autoCapitalize
- Settings persist across app restarts

## Testing
- Toggle spell-check on/off in Settings
- Type misspelled words like "teh" or "speling mistke"
- Verify red underlines appear when enabled, disappear when disabled
- Confirm settings persist after app restart

Fixes #8

🤖 Generated with [Claude Code](https://claude.ai/code)