### PR TITLE
Fix redundant enableSpellCheck defaults in Settings.jsx

### DIFF
--- a/src/renderer/pages/Settings.jsx
+++ b/src/renderer/pages/Settings.jsx
@@ -24,7 +24,6 @@ function Settings() {
     customApiBaseUrl: '',
     customModels: {},
     theme: 'light',
-    enableSpellCheck: true,
     builtInTools: {
       codeInterpreter: false,
       browserSearch: false
@@ -75,9 +74,6 @@ function Settings() {
         if (!settingsData.theme) {
             settingsData.theme = 'light';
         }
-        if (settingsData.enableSpellCheck === undefined) {
-            settingsData.enableSpellCheck = true;
-        }
         setSettings(settingsData);
       } catch (error) {
         console.error('Error loading settings:', error);
@@ -95,7 +91,6 @@ function Settings() {
             customApiBaseUrl: '',
             customModels: {},
             theme: 'light',
-            enableSpellCheck: true,
             builtInTools: {
                 codeInterpreter: false,
                 browserSearch: false


### PR DESCRIPTION
Remove redundant defaulting of enableSpellCheck to true on lines 27, 79, 98 since this is already properly handled by settingsManager.js with proper defaults and fallback logic.

Fixes #12

Generated with [Claude Code](https://claude.ai/code)