### PR TITLE
docs: add test:pipeline and pre-push hook documentation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,26 @@ pnpm dist:linux
 
 This project maintains comprehensive test coverage with a minimum requirement of 90% across all metrics (lines, branches, functions, and statements).
 
+#### Local Pipeline Testing
+
+**⚡ Run the exact same checks as GitHub Actions CI:**
+
+```bash
+# Run complete pipeline checks locally (mirrors GitHub Actions exactly)
+pnpm test:pipeline
+```
+
+This command runs:
+1. `pnpm run lint` - ESLint with zero warnings allowed
+2. `pnpm run test:ci` - Full test suite with coverage enforcement
+3. Coverage threshold validation (90% minimum)
+
+**🎯 Pre-Push Hook Protection:**
+- Automatically installed via Husky when you run `pnpm install`
+- Smart file filtering: Only runs on JS/JSX/TS/TSX/config files
+- Prevents pushes that would fail CI
+- Emergency bypass: `git push --no-verify` (use sparingly!)
+
 #### Test Scripts
 
 ```bash
@@ -139,6 +159,12 @@ pnpm test:watch
 
 # Run tests for CI/CD (enforces coverage thresholds)
 pnpm test:ci
+
+# Lint code (same command as CI)
+pnpm run lint
+
+# Run complete pipeline checks locally (mirrors GitHub Actions)
+pnpm test:pipeline
 ```
 
 #### Test Structure
@@ -174,6 +200,9 @@ pnpm test:coverage
 
 # View coverage report
 open coverage/lcov-report/index.html
+
+# Before pushing - run the same checks as CI
+pnpm test:pipeline
 ```
 
 ### Testing Cross-Platform Support
@@ -214,68 +243,6 @@ You can obtain a Groq API key by signing up at [https://console.groq.com](https:
 
 The app now includes a dark mode toggle in the Settings page. Toggle between light and dark themes, and your preference will persist across app restarts. The theme is applied immediately when changed and stored in your user settings.
 
-## Testing
-
-This project maintains a minimum test coverage of 90% across all metrics (lines, branches, functions, and statements). We use Jest as our testing framework with separate configurations for React components, Electron main process, and integration tests.
-
-### Running Tests
-
-```bash
-# Run all tests
-pnpm test
-
-# Run tests with coverage report
-pnpm test:coverage
-
-# Run only unit tests
-pnpm test:unit
-
-# Run only integration tests
-pnpm test:integration
-
-# Run tests in watch mode (for development)
-pnpm test:watch
-
-# Run tests in CI mode (with coverage enforcement)
-pnpm test:ci
-```
-
-### Test Structure
-
-- `__tests__/unit/` - Unit tests for utilities and helpers
-- `__tests__/integration/` - Integration tests for API and system interactions
-- `src/renderer/components/__tests__/` - React component tests
-- `electron/__tests__/` - Electron main process module tests
-
-### Coverage Requirements
-
-All code must maintain at least 90% test coverage. The build will fail if coverage falls below:
-- Lines: 90%
-- Branches: 90%
-- Functions: 90%
-- Statements: 90%
-
-View the coverage report after running tests:
-```bash
-pnpm test:coverage
-open coverage/index.html
-```
-
-### Writing Tests
-
-When contributing new features or fixes:
-1. Write tests for all new code
-2. Ensure existing tests still pass
-3. Update tests when modifying existing functionality
-4. Follow the existing test patterns in the codebase
-
-### Continuous Integration
-
-Tests are automatically run on all pull requests and pushes to main. The CI pipeline:
-- Runs tests across multiple OS (Ubuntu, macOS, Windows)
-- Checks coverage thresholds
-- Reports coverage metrics on PRs
-- Uploads coverage reports to Codecov
 
 ## Contributing
 


### PR DESCRIPTION
Add comprehensive documentation for the test:pipeline functionality and pre-push hooks introduced in PR #43.

## Changes
- ⚡ Added Local Pipeline Testing section with `pnpm test:pipeline` usage
- 🛡️ Documented pre-push hook protection with smart file filtering
- 📋 Enhanced test scripts documentation including new lint command
- 🧹 Consolidated duplicate testing sections for better clarity
- 🔗 Added emergency bypass instructions and usage examples

References the pipeline parity improvements from PR #43 that ensure developers run the exact same checks locally as GitHub Actions CI.

Generated with [Claude Code](https://claude.ai/code)