### PR TITLE
fix: correct incorrectly marked unused variables in error handling paths

### DIFF
--- a/__tests__/benchmarks/benchmark-jest.js
+++ b/__tests__/benchmarks/benchmark-jest.js
@@ -7,7 +7,6 @@
 
 const { spawn } = require('child_process');
 const fs = require('fs');
-const _path = require('path');
 
 function runJestCommand(command, cacheEnabled = true) {
   return new Promise((resolve, reject) => {

--- a/__tests__/benchmarks/benchmark-tests.js
+++ b/__tests__/benchmarks/benchmark-tests.js
@@ -6,7 +6,6 @@
  */
 
 const { spawn } = require('child_process');
-const _path = require('path');
 
 function runTest(testFile) {
   return new Promise((resolve, reject) => {

--- a/__tests__/integration/api-resilience.test.js
+++ b/__tests__/integration/api-resilience.test.js
@@ -197,7 +197,7 @@ describe('API Resilience Integration Tests', () => {
   describe('Circuit Breaker Pattern', () => {
     test('opens circuit after consecutive failures', async () => {
       let circuitOpen = false;
-      let _failureCount = 0;
+      let failureCount = 0;
       const maxFailures = 3;
       const cooldownPeriod = 1000; // 1 second
       let lastFailureTime = 0;
@@ -213,7 +213,7 @@ describe('API Resilience Integration Tests', () => {
         // Check if circuit is open and cooldown period has passed
         if (circuitOpen && now - lastFailureTime > cooldownPeriod) {
           circuitOpen = false;
-          _failureCount = 0;
+          failureCount = 0;
         }
 
         // If circuit is open, fail fast
@@ -229,10 +229,10 @@ describe('API Resilience Integration Tests', () => {
           });
 
           if (!response.ok && response.status >= 500) {
-            _failureCount++;
+            failureCount++;
             lastFailureTime = now;
 
-            if (_failureCount >= maxFailures) {
+            if (failureCount >= maxFailures) {
               circuitOpen = true;
             }
 
@@ -241,13 +241,13 @@ describe('API Resilience Integration Tests', () => {
           }
 
           // Reset failure count on success
-          _failureCount = 0;
+          failureCount = 0;
           return await response.json();
         } catch (error) {
-          _failureCount++;
+          failureCount++;
           lastFailureTime = now;
 
-          if (_failureCount >= maxFailures) {
+          if (failureCount >= maxFailures) {
             circuitOpen = true;
           }
 
@@ -271,7 +271,7 @@ describe('API Resilience Integration Tests', () => {
 
     test('half-opens circuit after cooldown period', async () => {
       let circuitOpen = true;
-      let __failureCount = 3;
+      let failureCount = 3;
       const cooldownPeriod = 100; // Short period for testing
       let lastFailureTime = Date.now() - cooldownPeriod - 10; // Past cooldown
 
@@ -284,7 +284,7 @@ describe('API Resilience Integration Tests', () => {
         // Check if circuit can be half-opened
         if (circuitOpen && now - lastFailureTime > cooldownPeriod) {
           circuitOpen = false;
-          __failureCount = 0;
+          failureCount = 0;
         }
 
         if (circuitOpen) {
@@ -309,7 +309,7 @@ describe('API Resilience Integration Tests', () => {
 
   describe('Timeout Handling', () => {
     test('handles request timeouts', async () => {
-      const _timeoutScope = mockGroqTimeout();
+      mockGroqTimeout();
 
       const makeApiCallWithTimeout = async (timeoutMs = 1000) => {
         const controller = new AbortController();

--- a/__tests__/integration/electron-renderer-communication.test.js
+++ b/__tests__/integration/electron-renderer-communication.test.js
@@ -369,7 +369,6 @@ describe('Electron Main-Renderer Communication Integration Tests', () => {
     });
 
     test('handles rapid sequential messages', async () => {
-      const _results = [];
 
       mockIpcMain.handle('rapid-message', async (event, id) => {
         await new Promise((resolve) => setTimeout(resolve, 10));

--- a/__tests__/unit/electron/settingsManager.test.js
+++ b/__tests__/unit/electron/settingsManager.test.js
@@ -1,6 +1,5 @@
 const settingsManager = require('../../../electron/settingsManager');
 const fs = require('fs');
-const _path = require('path');
 
 describe('SettingsManager', () => {
   const mockApp = {

--- a/__tests__/unit/electron/utils.test.js
+++ b/__tests__/unit/electron/utils.test.js
@@ -1,5 +1,4 @@
 const utils = require('../../../electron/utils');
-const _path = require('path');
 
 describe('Electron Utils', () => {
   beforeEach(() => {

--- a/__tests__/unit/security/permission-errors.test.js
+++ b/__tests__/unit/security/permission-errors.test.js
@@ -7,12 +7,9 @@ const settingsManager = require('../../../electron/settingsManager');
 
 describe('Permission Error Handling (No Mocks)', () => {
   let testDir;
-  let _originalChmod;
-
   beforeEach(() => {
     // Create a temporary directory for permission tests
     testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'groq-permission-test-'));
-    _originalChmod = fs.chmod;
   });
 
   afterEach(() => {

--- a/electron/authManager.js
+++ b/electron/authManager.js
@@ -27,7 +27,7 @@ const storageHas = promisify(storage.has);
 const ACTIVE_FLOWS_KEY = 'activeAuthFlows';
 let localCallbackServer = null; // Holds the HTTP server instance
 let localCallbackPort = null; // Holds the port the server is listening on
-let _mcpRetryFunc = null; // Variable to hold injected retry function
+let mcpRetryFunc = null; // Variable to hold injected retry function
 
 (async () => {
   try {
@@ -315,8 +315,8 @@ async function processCallbackParams(authorizationCode, receivedState) {
     console.log(
       `[AuthManager][${serverId}] Passing access token: ${tokens?.access_token ? tokens.access_token.substring(0, 10) + '...' : 'MISSING/EMPTY'}`
     );
-    if (typeof _mcpRetryFunc === 'function') {
-      _mcpRetryFunc(serverId, tokens.access_token);
+    if (typeof mcpRetryFunc === 'function') {
+      mcpRetryFunc(serverId, tokens.access_token);
     } else {
       console.error(`[AuthManager][${serverId}] MCP Manager retry function not injected/found!`);
     }
@@ -431,10 +431,10 @@ function initialize(retryFunc) {
   // Accept the function directly
   if (typeof retryFunc !== 'function') {
     console.error('[AuthManager] Invalid retry function passed to initialize.');
-    _mcpRetryFunc = null;
+    mcpRetryFunc = null;
     return;
   }
-  _mcpRetryFunc = retryFunc;
+  mcpRetryFunc = retryFunc;
   console.log('[AuthManager] Initialized with MCP Manager retry function.');
 }
 

--- a/electron/main.js
+++ b/electron/main.js
@@ -44,7 +44,7 @@ const PopupWindowManager = require('./popupWindow');
 let mainWindow;
 
 // Variable to hold loaded model context sizes
-let _modelContextSizes = {};
+let modelContextSizes = {};
 
 // --- Context Sharing State ---
 let pendingContext = null; // Holds context to be passed to renderer
@@ -196,11 +196,11 @@ app.whenReady().then(async () => {
 
   // Load model context sizes from the JS module
   try {
-    _modelContextSizes = MODEL_CONTEXT_SIZES;
+    modelContextSizes = MODEL_CONTEXT_SIZES;
     console.log('Successfully loaded shared model definitions.');
   } catch (error) {
     console.error('Failed to load shared model definitions:', error);
-    _modelContextSizes = { default: { context: 8192, vision_supported: false } }; // Fallback
+    modelContextSizes = { default: { context: 8192, vision_supported: false } }; // Fallback
   } // --- Early IPC Handlers required by popup and renderer before other init --- //
   ipcMain.handle('get-model-configs', async () => {
     // Return a copy to prevent accidental modification with custom models merged in


### PR DESCRIPTION
From PR #65 audit, found several variables marked as unused that are actually used in error handling and conditional paths:

**Critical fixes:**
- Rename _mcpRetryFunc to mcpRetryFunc in electron/authManager.js (used in OAuth retry logic)
- Rename _modelContextSizes to modelContextSizes in electron/main.js (used for model config)
- Rename _failureCount to failureCount in api-resilience.test.js (used in circuit breaker)

**Safe removals:**
- Remove truly unused variables: _results, _timeoutScope, _originalChmod, _path imports

Prevents potential runtime errors in error handling scenarios.

Fixes #68

Generated with [Claude Code](https://claude.ai/code)